### PR TITLE
Upgrade to jenkins-status-alerts-and-reporting@v1.4.0

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Jenkins Alert and Reporting
-        uses: UlisesGascon/jenkins-status-alerts-and-reporting@v1.3.0
+        uses: UlisesGascon/jenkins-status-alerts-and-reporting@v1.4.0
         id: jenkins-status-alerts-and-reporting
         with:
           database: monitor/database.json


### PR DESCRIPTION
Release notes: https://github.com/UlisesGascon/jenkins-status-alerts-and-reporting/releases/tag/v1.4.0